### PR TITLE
Import ccnmtlsettings and adapt some functionality

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,17 @@
+name: build-and-test
+on: [push, workflow_dispatch]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+          python-version: [3.8]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Flake
+        run: |
+          python -m pip install flake8
+
+      - name: Run Flake
+        run: flake8 ctlsettings

--- a/README.md
+++ b/README.md
@@ -1,2 +1,141 @@
-# ctlsettings
-our common django settings (based on ccnmtlsettings)
+[![Actions Status](https://github.com/ccnmtl/ctlsettings/workflows/build-and-test/badge.svg)](https://github.com/ccnmtl/ctlsettings/actions)
+
+These are the common settings we use across all our Django apps,
+extracted into a handy reusable module.
+
+## Usage
+
+### Installation
+
+First, install it with
+
+    $ pip install ctlsettings
+
+or add `ctlsettings==0.1.0` to your `requirements.txt`.
+
+### Dependencies
+
+The following libraries are used in some way, so they'll need to be installed:
+
+* django-debug-toolbar
+* coverage
+* django-smoketest
+* django-extensions
+* django-statsd-mozilla
+* django-storages
+* django-impersonate
+* boto3
+* django-cacheds3storage
+* sentry-sdk
+* statsd
+* gunicorn
+
+### Use it
+
+`ctlsettings` has three "environments" (for now) that you will want
+to make use of: `shared`, `staging`, and `production`.
+
+In your `settings_shared.py` you will want to do something like:
+
+	import os.path
+	from ctlsettings.shared import common
+
+	project = 'yourapp'
+	base = os.path.dirname(__file__)
+
+	locals().update(common(project=project, base=base))
+
+    # which apps should jenkins include in coverage reports?
+	PROJECT_APPS = [
+		'yourapp.main',
+	]
+
+	INSTALLED_APPS += [  # noqa
+		'yourapp.main',
+	]
+
+
+Most of the magic is on the `locals().update(...)` line. That's where
+the `common` function from `ctlsettings.shared` is called with
+simple configuration and returns a bunch of variables, which are then
+injected into the local symbol table. The two requires parameters are
+`project` and `base`.
+
+`project` is the name of your project. It should be lowercase with
+just alphanumeric characters. Most likely, just the name of the
+directory for your project.
+
+`base` is the full path of the directory that `settings_shared.py` is
+in.
+
+After that, a few settings that `ctlsettings` can't fully set up are
+set and/or modified. In particular, the project's apps are added to
+`INSTALLED_APPS`.
+
+An important note is that because of the weird symbol table tweaking
+done earlier, flake8 will complain if you try to modify a variable
+that comes out of `ctlsettings`, since it didn't see where it got
+defined. You need to add the `# noqa` line to each variable that you
+modify this way to get it to ignore it.
+
+You'll do almost the same thing for your `settings_staging.py` and
+`settings_production.py`:
+
+	from myapp.settings_shared import *
+	from ctlsettings.staging import common
+	import os
+
+	project = 'yourapp'
+	base = os.path.dirname(__file__)
+
+	locals().update(
+		common(
+			project=project,
+			base=base,
+			STATIC_ROOT=STATIC_ROOT,
+			INSTALLED_APPS=INSTALLED_APPS,
+			cloudfront='some-cloudfront-id',
+		))
+
+	try:
+		from myapp.local_settings import *
+	except ImportError:
+		pass
+
+(and the same thing for `settings_production.py`, but with `from
+ctlsettings.production import common` instead.)
+
+Again, you are passing in `project`, and `base`. The
+staging/production settings also need to have access to `STATIC_ROOT`
+and `INSTALLED_APPS`, so those must be passed in.
+
+Finally, there are a couple variables related to static file
+deployment that you may or may not want to set:
+
+`s3static` is a boolean. It defaults to `True` and tells
+`ctlsettings` that you are using S3 for serving static
+files. Mainly, you will want to set this to `False` if your
+application is not yet serving static files off S3.
+
+`cloudfront` is a cloudfront id. If you pass it in, AWS Cloudfront
+will be used for the static files URLs.
+
+## Recommendations
+
+If you're converting an existing app to `ctlsettings`, which I
+recommend is:
+
+* install `ctlsettings` and any libraries it requires
+* add the `ctlsettings` related stuff to the top of your
+  `settings_shared.py` and set up the basic configuration, but leave
+  all your settings in place after it (effectively overriding
+  everything that `ctlsettings` is pulling in).
+* pull up
+  https://github.com/ccnmtl/ctlsettings/blob/master/ctlsettings/shared.py
+  in a browser.
+* line by line, setting by setting, compare what you have in your
+  `settings_shared.py` with what `ctlsettings` has for the same
+  variable. Delete yours if they are the same. Otherwise leave yours
+  in place (or append the differences if it's a list variable).
+* run your tests/flake8 each time.
+* do the same for staging/production.

--- a/ctlsettings/production.py
+++ b/ctlsettings/production.py
@@ -1,0 +1,77 @@
+def common(**kwargs):
+    # required args
+    project = kwargs['project']
+    base = kwargs['base']
+    STATIC_ROOT = kwargs['STATIC_ROOT']
+    INSTALLED_APPS = kwargs['INSTALLED_APPS']
+
+    # optional args
+    s3static = kwargs.get('s3static', True)
+    cloudfront = kwargs.get('cloudfront', None)
+    s3prefix = kwargs.get('s3prefix', 'ctl')
+
+    DEBUG = False
+
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': project,
+            'HOST': '',
+            'PORT': 6432,
+            'USER': '',
+            'PASSWORD': '',
+            'ATOMIC_REQUESTS': True,
+        }
+    }
+
+    MEDIA_ROOT = '/var/www/' + project + '/uploads/'
+
+    STATICMEDIA_MOUNTS = [
+        ('/sitemedia', '/var/www/' + project + '/' + project + '/sitemedia'),
+    ]
+
+    if s3static:
+        # serve static files off S3
+        AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-prod"
+        AWS_S3_OBJECT_PARAMETERS = {
+            'ACL': 'public-read',
+        }
+        AWS_PRELOAD_METADATA = True
+        STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+        if cloudfront:
+            AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
+            S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
+            STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+        else:
+            S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+            STATIC_URL = ('https://%s.s3.amazonaws.com/media/'
+                          % AWS_STORAGE_BUCKET_NAME)
+
+        DEFAULT_FILE_STORAGE = 'cacheds3storage.MediaRootS3BotoStorage'
+        MEDIA_URL = S3_URL + 'uploads/'
+        AWS_QUERYSTRING_AUTH = False
+    else:
+        # non S3 mode
+        STATICFILES_DIRS = ()
+        STATIC_ROOT = "/var/www/" + project + "/" + project + "/media/"
+
+    LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'handlers': {
+            'file': {
+                'level': 'INFO',
+                'class': 'logging.FileHandler',
+                'filename': '/var/log/django/' + project + '.log',
+            },
+        },
+        'loggers': {
+            'django': {
+                'handlers': ['file'],
+                'level': 'INFO',
+                'propagate': True,
+            },
+        },
+    }
+
+    return locals()

--- a/ctlsettings/shared.py
+++ b/ctlsettings/shared.py
@@ -1,0 +1,158 @@
+import os.path
+import sys
+
+
+def common(**kwargs):
+    # required args
+    project = kwargs['project']
+    base = kwargs['base']
+
+    DEBUG = True
+
+    ADMINS = []
+    MANAGERS = ADMINS
+
+    ALLOWED_HOSTS = [
+        '.ctl.columbia.edu',
+        '.ccnmtl.columbia.edu',
+        'localhost',
+    ]
+
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': project,
+            'HOST': '',
+            'PORT': 5432,
+            'USER': '',
+            'PASSWORD': '',
+            'ATOMIC_REQUESTS': True,
+        }
+    }
+
+    if 'test' in sys.argv or 'jenkins' in sys.argv:
+        DATABASES = {
+            'default': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': ':memory:',
+                'HOST': '',
+                'PORT': '',
+                'USER': '',
+                'PASSWORD': '',
+                'ATOMIC_REQUESTS': True,
+            }
+        }
+
+        PASSWORD_HASHERS = (
+            'django.contrib.auth.hashers.MD5PasswordHasher',
+        )
+
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'
+
+    TIME_ZONE = 'America/New_York'
+    LANGUAGE_CODE = 'en-us'
+    SITE_ID = 1
+    USE_I18N = False
+    MEDIA_ROOT = "/var/www/" + project + "/uploads/"
+    MEDIA_URL = '/uploads/'
+    STATIC_URL = '/media/'
+    SECRET_KEY = 'you must override this'
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [
+                os.path.join(base, "templates"),
+            ],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    # Insert your TEMPLATE_CONTEXT_PROCESSORS here or use this
+                    # list if you haven't customized them:
+                    'django.contrib.auth.context_processors.auth',
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.media',
+                    'django.template.context_processors.static',
+                    'django.template.context_processors.tz',
+                    'django.template.context_processors.request',
+                    'django.contrib.messages.context_processors.messages',
+                    'stagingcontext.staging_processor',
+                    'gacontext.ga_processor',
+                ],
+            },
+        },
+    ]
+
+    MIDDLEWARE = [
+        'django_statsd.middleware.GraphiteRequestTimingMiddleware',
+        'django_statsd.middleware.GraphiteMiddleware',
+        'django.middleware.common.CommonMiddleware',
+        'django.contrib.sessions.middleware.SessionMiddleware',
+        'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
+        'impersonate.middleware.ImpersonateMiddleware',
+        'django.middleware.security.SecurityMiddleware',
+        'django.middleware.clickjacking.XFrameOptionsMiddleware'
+    ]
+
+    ROOT_URLCONF = project + '.urls'
+
+    INSTALLED_APPS = [
+        'django.contrib.auth',
+        'django.contrib.contenttypes',
+        'django.contrib.sessions',
+        'django.contrib.sites',
+        'django.contrib.flatpages',
+        'django.contrib.staticfiles',
+        'django.contrib.messages',
+        'django.contrib.admin',
+        'django_statsd',
+        'smoketest',
+        'gunicorn',
+        'impersonate',
+    ]
+
+    INTERNAL_IPS = ['127.0.0.1']
+
+    STATSD_CLIENT = 'statsd.client'
+    STATSD_PREFIX = project
+    STATSD_HOST = 'localhost'
+    STATSD_PORT = 8125
+
+    THUMBNAIL_SUBDIR = "thumbs"
+    EMAIL_SUBJECT_PREFIX = "[" + project + "] "
+    EMAIL_HOST = 'localhost'
+    SERVER_EMAIL = project + "-noreply@mail.ctl.columbia.edu"
+    DEFAULT_FROM_EMAIL = SERVER_EMAIL
+
+    STATICMEDIA_MOUNTS = [
+        ('/sitemedia', 'sitemedia'),
+    ]
+
+    # CAS settings
+
+    AUTHENTICATION_BACKENDS = [
+        'django.contrib.auth.backends.ModelBackend',
+    ]
+
+    CAS_BASE = "https://cas.columbia.edu/"
+
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTOCOL', 'https')
+    SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
+
+    SESSION_COOKIE_HTTPONLY = True
+    SESSION_COOKIE_SECURE = True
+
+    CSRF_COOKIE_SECURE = True
+    CSRF_COOKIE_HTTPONLY = True
+
+    STATIC_ROOT = "/tmp/" + project + "/static"
+    STATICFILES_DIRS = ["media/"]
+    STATICFILES_FINDERS = [
+        'django.contrib.staticfiles.finders.FileSystemFinder',
+        'django.contrib.staticfiles.finders.AppDirectoriesFinder',
+    ]
+
+    GRAPHITE_BASE = "https://graphite.ctl.columbia.edu/render/"
+
+    return locals()

--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -1,0 +1,80 @@
+def common(**kwargs):
+    # required args
+    project = kwargs['project']
+    base = kwargs['base']
+    STATIC_ROOT = kwargs['STATIC_ROOT']
+    INSTALLED_APPS = kwargs['INSTALLED_APPS']
+
+    # optional args
+    s3static = kwargs.get('s3static', True)
+    cloudfront = kwargs.get('cloudfront', None)
+    s3prefix = kwargs.get('s3prefix', 'ctl')
+
+    DEBUG = False
+    STAGING_ENV = True
+
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.postgresql',
+            'NAME': project,
+            'HOST': '',
+            'PORT': 6432,
+            'USER': '',
+            'PASSWORD': '',
+            'ATOMIC_REQUESTS': True,
+        }
+    }
+
+    STATSD_PREFIX = project + "-staging"
+
+    MEDIA_ROOT = '/var/www/' + project + '/uploads/'
+
+    # put any static media here to override app served static media
+    STATICMEDIA_MOUNTS = [
+        ('/sitemedia', '/var/www/' + project + '/' + project + '/sitemedia'),
+    ]
+
+    if s3static:
+        # serve static files off S3
+        AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-stage"
+        AWS_S3_OBJECT_PARAMETERS = {
+            'ACL': 'public-read',
+        }
+        AWS_PRELOAD_METADATA = True
+        STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+        if cloudfront:
+            AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
+            S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
+            STATIC_URL = 'https://%s/media/' % AWS_S3_CUSTOM_DOMAIN
+        else:
+            S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+            STATIC_URL = ('https://%s.s3.amazonaws.com/media/'
+                          % AWS_STORAGE_BUCKET_NAME)
+        DEFAULT_FILE_STORAGE = 'cacheds3storage.MediaRootS3BotoStorage'
+        MEDIA_URL = S3_URL + 'uploads/'
+        AWS_QUERYSTRING_AUTH = False
+    else:
+        # non S3 mode
+        STATICFILES_DIRS = ()
+        STATIC_ROOT = "/var/www/" + project + "/" + project + "/media/"
+
+    LOGGING = {
+        'version': 1,
+        'disable_existing_loggers': False,
+        'handlers': {
+            'file': {
+                'level': 'INFO',
+                'class': 'logging.FileHandler',
+                'filename': '/var/log/django/' + project + '.log',
+            },
+        },
+        'loggers': {
+            'django': {
+                'handlers': ['file'],
+                'level': 'INFO',
+                'propagate': True,
+            },
+        },
+    }
+
+    return locals()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,30 @@
+from setuptools import setup
+
+setup(
+    name='ctlsettings',
+    version='0.1.0',
+    author='Columbia University Center for Teaching and Learning',
+    author_email='ctl-dev@columbia.edu',
+    url='https://github.com/ccnmtl/ctlsettings',
+    description='Columbia CTL common Django base settings',
+    long_description='common settings we use across all our projects',
+    install_requires = [
+        'django-debug-toolbar',
+        'coverage',
+        'django-smoketest',
+        'django-extensions',
+        'django-statsd-mozilla',
+        'sentry-sdk',
+        'django-storages',
+        'boto3',
+        'django-cacheds3storage',
+        'statsd',
+        'gunicorn',
+        'django-impersonate',
+    ],
+    scripts = [],
+    license = 'GPL-3.0-or-later',
+    platforms = ['any'],
+    package_data = {'' : ['*.*']},
+    packages=['ctlsettings'],
+)


### PR DESCRIPTION
I am in the process of migrating ccnmtlsettings to this new library, `ctlsettings`, as it just seems to make sense - there are a number of breaking changes I want to introduce, and this new library will allow us to push these changes out gradually. We also might as well finally rename this as we haven't been the CCNMTL since 2015.

* Removed django-markwhat, django-compressor, djangowind, and their configuration settings.
* Updated a few instances of the 'ccnmtl' string to 'ctl'

Next steps: introduce a generalized django-cas-ng configuration into this library, based on one of our existing django apps that use it, such as econplayground.