### PR TITLE
django-storages: remove deprecated AWS_PRELOAD_METADATA setting

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.1.1
+====================
+* django-storages: remove deprecated AWS_PRELOAD_METADATA setting
+
 0.1.0 (2023-02-17)
 ====================
 Initial release

--- a/ctlsettings/production.py
+++ b/ctlsettings/production.py
@@ -36,7 +36,6 @@ def common(**kwargs):
         AWS_S3_OBJECT_PARAMETERS = {
             'ACL': 'public-read',
         }
-        AWS_PRELOAD_METADATA = True
         STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'

--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -40,7 +40,6 @@ def common(**kwargs):
         AWS_S3_OBJECT_PARAMETERS = {
             'ACL': 'public-read',
         }
-        AWS_PRELOAD_METADATA = True
         STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'


### PR DESCRIPTION
https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst#s3-8