### PR TITLE
Add timezone support to default setup

### DIFF
--- a/ctlsettings/shared.py
+++ b/ctlsettings/shared.py
@@ -50,6 +50,7 @@ def common(**kwargs):
     TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
     TIME_ZONE = 'America/New_York'
+    USE_TZ = True
     LANGUAGE_CODE = 'en-us'
     SITE_ID = 1
     USE_I18N = False


### PR DESCRIPTION
Disabled by default, but all our applications are enabling in app-specific settings files anyways.

https://docs.djangoproject.com/en/3.2/topics/i18n/timezones/