### PR TITLE
Remove django-cacheds3storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ The following libraries are used in some way, so they'll need to be installed:
 * django-storages
 * django-impersonate
 * boto3
-* django-cacheds3storage
 * sentry-sdk
 * statsd
 * gunicorn

--- a/ctlsettings/production.py
+++ b/ctlsettings/production.py
@@ -36,7 +36,9 @@ def common(**kwargs):
         AWS_S3_OBJECT_PARAMETERS = {
             'ACL': 'public-read',
         }
-        STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+        DEFAULT_FILE_STORAGE = 'ctlsettings.storages.UploadsStorage'
+        STATICFILES_STORAGE = 'ctlsettings.storages.MediaStorage'
+
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
             S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
@@ -46,7 +48,6 @@ def common(**kwargs):
             STATIC_URL = ('https://%s.s3.amazonaws.com/media/'
                           % AWS_STORAGE_BUCKET_NAME)
 
-        DEFAULT_FILE_STORAGE = 'cacheds3storage.MediaRootS3BotoStorage'
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False
     else:

--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -40,7 +40,9 @@ def common(**kwargs):
         AWS_S3_OBJECT_PARAMETERS = {
             'ACL': 'public-read',
         }
-        STATICFILES_STORAGE = 'cacheds3storage.CompressorS3BotoStorage'
+        DEFAULT_FILE_STORAGE = 'ctlsettings.storages.UploadsStorage'
+        STATICFILES_STORAGE = 'ctlsettings.storages.MediaStorage'
+
         if cloudfront:
             AWS_S3_CUSTOM_DOMAIN = cloudfront + '.cloudfront.net'
             S3_URL = 'https://%s/' % AWS_S3_CUSTOM_DOMAIN
@@ -49,7 +51,7 @@ def common(**kwargs):
             S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
             STATIC_URL = ('https://%s.s3.amazonaws.com/media/'
                           % AWS_STORAGE_BUCKET_NAME)
-        DEFAULT_FILE_STORAGE = 'cacheds3storage.MediaRootS3BotoStorage'
+
         MEDIA_URL = S3_URL + 'uploads/'
         AWS_QUERYSTRING_AUTH = False
     else:

--- a/ctlsettings/storages.py
+++ b/ctlsettings/storages.py
@@ -1,0 +1,9 @@
+from storages.backends.s3boto3 import S3Boto3Storage, S3StaticStorage
+
+
+class UploadsStorage(S3Boto3Storage):
+    location = 'uploads'
+
+
+class MediaStorage(S3StaticStorage):
+    location = 'media'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
         'sentry-sdk',
         'django-storages',
         'boto3',
-        'django-cacheds3storage',
         'statsd',
         'gunicorn',
         'django-impersonate',


### PR DESCRIPTION
Replace with simpler storages.py file which just defines our custom storage locations, inheriting directly from django-storages' storage classes.

The problem that django-cacheds3storage was seems to have been resolved upstream in django-storages.