### PR TITLE
Use CAS_MAP_AFFILIATIONS=True by default

### DIFF
--- a/ctlsettings/shared.py
+++ b/ctlsettings/shared.py
@@ -146,6 +146,7 @@ def common(**kwargs):
     CAS_SERVER_URL = 'https://cas.columbia.edu/cas/'
     CAS_VERSION = '3'
     CAS_ADMIN_REDIRECT = False
+    CAS_MAP_AFFILIATIONS = True
 
     # Translate CUIT's CAS user attributes to the Django user model.
     # https://cuit.columbia.edu/content/cas-3-ticket-validation-response


### PR DESCRIPTION
This creates a django Group for each cas affiliation on login. Only works on latest git master version of django-cas-ng: https://github.com/django-cas-ng/django-cas-ng/pull/318