### PR TITLE
Add CSRF_TRUSTED_ORIGINS config

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.3.2
+====================
+* Added CSRF_TRUSTED_ORIGINS config for Django >= 4.0
+
 0.3.1 (2024-01-08)
 ====================
 * fixed typo for http forwarded setting

--- a/ctlsettings/shared.py
+++ b/ctlsettings/shared.py
@@ -36,6 +36,10 @@ def common(**kwargs):
     if public_ip:
         ALLOWED_HOSTS += [public_ip]
 
+    CSRF_TRUSTED_ORIGINS = [
+        'https://*.ctl.columbia.edu',
+    ]
+
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.postgresql',


### PR DESCRIPTION
This is required by Django >= 4.0. See:
https://github.com/ccnmtl/econplayground/pull/2963