### PR TITLE
Configure log rotation for django logs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 0.3.2
 ====================
 * Added CSRF_TRUSTED_ORIGINS config for Django >= 4.0
+* Use log rotation for django logs
 
 0.3.1 (2024-01-08)
 ====================

--- a/ctlsettings/production.py
+++ b/ctlsettings/production.py
@@ -81,7 +81,9 @@ def common(**kwargs):
         'handlers': {
             'file': {
                 'level': 'INFO',
-                'class': 'logging.FileHandler',
+                'class': 'logging.handlers.RotatingFileHandler',
+                'backupCount': 4,
+                'maxBytes': 10*1024*1024,
                 'filename': '/var/log/django/' + project + '.log',
                 'formatter': 'timestamped',
             },

--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -86,7 +86,9 @@ def common(**kwargs):
         'handlers': {
             'file': {
                 'level': 'INFO',
-                'class': 'logging.FileHandler',
+                'class': 'logging.handlers.RotatingFileHandler',
+                'backupCount': 4,
+                'maxBytes': 10*1024*1024,
                 'filename': '/var/log/django/' + project + '.log',
                 'formatter': 'timestamped',
             },


### PR DESCRIPTION
Limits log files to 10mb with four backup logs