### PR TITLE
Refactor get_ec2_instance_ip logic

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.3.3
+====================
+* Added token process to get_ec2_instance_ip()
+
 0.3.2 (2024-04-16)
 ====================
 * Added CSRF_TRUSTED_ORIGINS config for Django >= 4.0


### PR DESCRIPTION
I've refactored the `try` blocks to only contain the lines which would fail with the expected exception. This is the general best practice we use with try/except.