### PR TITLE
Refactored common sentry setup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.3.4
+====================
+* Introduced init_sentry function for staging and production.
+
 0.3.3 (2024-08-15)
 ====================
 * Added token process to get_ec2_instance_ip()

--- a/ctlsettings/production.py
+++ b/ctlsettings/production.py
@@ -14,7 +14,6 @@ def common(**kwargs):
     s3static = kwargs.get('s3static', True)
     cloudfront = kwargs.get('cloudfront', None)
     s3prefix = kwargs.get('s3prefix', 'ctl')
-    sentry_dsn = kwargs.get('sentry_dsn', None)
 
     DEBUG = False
 
@@ -29,14 +28,6 @@ def common(**kwargs):
             'ATOMIC_REQUESTS': True,
         }
     }
-
-    if sentry_dsn and \
-        ('migrate' not in sys.argv) and \
-            ('collectstatic' not in sys.argv):
-        sentry_sdk.init(
-            dsn=sentry_dsn,  # noqa: F405
-            integrations=[DjangoIntegration()],
-        )
 
     MEDIA_ROOT = '/var/www/' + project + '/uploads/'
 
@@ -98,3 +89,13 @@ def common(**kwargs):
     }
 
     return locals()
+
+
+def init_sentry(sentry_dsn: str) -> None:
+    if sentry_dsn and \
+        ('migrate' not in sys.argv) and \
+            ('collectstatic' not in sys.argv):
+        sentry_sdk.init(
+            dsn=sentry_dsn,
+            integrations=[DjangoIntegration()],
+        )

--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -14,7 +14,6 @@ def common(**kwargs):
     s3static = kwargs.get('s3static', True)
     cloudfront = kwargs.get('cloudfront', None)
     s3prefix = kwargs.get('s3prefix', 'ctl')
-    sentry_dsn = kwargs.get('sentry_dsn', None)
 
     DEBUG = False
     STAGING_ENV = True
@@ -30,15 +29,6 @@ def common(**kwargs):
             'ATOMIC_REQUESTS': True,
         }
     }
-
-    if sentry_dsn and \
-        ('migrate' not in sys.argv) and \
-            ('collectstatic' not in sys.argv):
-        sentry_sdk.init(
-            dsn=sentry_dsn,  # noqa: F405
-            integrations=[DjangoIntegration()],
-            debug=True,
-        )
 
     STATSD_PREFIX = project + "-staging"
 
@@ -103,3 +93,14 @@ def common(**kwargs):
     }
 
     return locals()
+
+
+def init_sentry(sentry_dsn: str) -> None:
+    if sentry_dsn and \
+        ('migrate' not in sys.argv) and \
+            ('collectstatic' not in sys.argv):
+        sentry_sdk.init(
+            dsn=sentry_dsn,
+            integrations=[DjangoIntegration()],
+            debug=True,
+        )


### PR DESCRIPTION
Many of our applications are not actually connected to sentry, for example:
https://github.com/ccnmtl/footprints/blob/master/footprints/settings_production.py#L5

The ctlsettings common() method requires the `sentry_dsn` param to be set, which isn't in this case, and isn't available until local_settings is imported.

Some applications are set up for sentry where they init sentry within the application: https://github.com/ccnmtl/mediathread/blob/master/mediathread/settings_production.py#L49

With this update to ctlsettings, applications can call the common code to initialize sentry using a pattern like this:
```
from ctlsettings.production import init_sentry

""" after local_settings import """

if hasattr(settings, 'SENTRY_DSN'):
    init_sentry(SENTRY_DSN)
```