### PR TITLE
Remove database config from staging.py

### DIFF
--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -18,18 +18,6 @@ def common(**kwargs):
     DEBUG = False
     STAGING_ENV = True
 
-    DATABASES = {
-        'default': {
-            'ENGINE': 'django.db.backends.postgresql',
-            'NAME': project,
-            'HOST': '',
-            'PORT': 6432,
-            'USER': '',
-            'PASSWORD': '',
-            'ATOMIC_REQUESTS': True,
-        }
-    }
-
     STATSD_PREFIX = project + "-staging"
 
     MEDIA_ROOT = '/var/www/' + project + '/uploads/'


### PR DESCRIPTION
This configuration connects to pgbouncer, which we are no longer using in staging. Our RDS Proxy config requires secrets which don't belong in ctlsettings, and this configuration is now in local_settings.py in salt, for the time being.