### PR TITLE
Add ENVIRONMENT setting to staging/production configs

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+0.3.6
+====================
+* Added ENVIRONMENT django setting, denoting either 'staging' or
+  'production'
+
 0.3.5 (2024-10-08)
 ====================
 * Updated sentry_init to include environment tag.

--- a/ctlsettings/production.py
+++ b/ctlsettings/production.py
@@ -16,6 +16,7 @@ def common(**kwargs):
     s3prefix = kwargs.get('s3prefix', 'ctl')
 
     DEBUG = False
+    ENVIRONMENT = 'production'
 
     DATABASES = {
         'default': {

--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -17,6 +17,7 @@ def common(**kwargs):
 
     DEBUG = False
     STAGING_ENV = True
+    ENVIRONMENT = 'staging'
 
     STATSD_PREFIX = project + "-staging"
 


### PR DESCRIPTION
This django setting will help us differentiate between production and development environments when initializing Sentry.