### PR TITLE
Add custom context processor

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+0.3.7
+====================
+* Added a custom context processor to make settings available in
+  templates.
+
 0.3.6 (2024-10-09)
 ====================
 * Added ENVIRONMENT django setting, denoting either 'staging' or

--- a/ctlsettings/context_processors.py
+++ b/ctlsettings/context_processors.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+
+
+def env(request):
+    """
+    Environment variables from settings for use in templates.
+    """
+    return {
+        'STAGING_ENV': getattr(settings, 'STAGING_ENV', False),
+        'ENVIRONMENT': getattr(settings, 'ENVIRONMENT', 'development'),
+    }

--- a/ctlsettings/shared.py
+++ b/ctlsettings/shared.py
@@ -125,6 +125,7 @@ def common(**kwargs):
                     'django.template.context_processors.request',
                     'django.contrib.messages.context_processors.messages',
                     'stagingcontext.staging_processor',
+                    'ctlsettings.context_processors.env',
                     'gacontext.ga_processor',
                 ],
             },


### PR DESCRIPTION
This context processor actually belongs within ctlsettings I think, since these variables are defined here, rather than the django-stagingcontext package.