### PR TITLE
Add ctlsettings/sentry_js.html template partial

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,9 @@
 ====================
 * Added a custom context processor to make settings available in
   templates.
+* Added 'testing' environment when running tests.
+* Added sentry_js.html template partial, to unify the code for this
+  setup.
 
 0.3.6 (2024-10-09)
 ====================

--- a/ctlsettings/context_processors.py
+++ b/ctlsettings/context_processors.py
@@ -8,4 +8,5 @@ def env(request):
     return {
         'STAGING_ENV': getattr(settings, 'STAGING_ENV', False),
         'ENVIRONMENT': getattr(settings, 'ENVIRONMENT', 'development'),
+        'SENTRY_KEY': getattr(settings, 'SENTRY_KEY', None),
     }

--- a/ctlsettings/shared.py
+++ b/ctlsettings/shared.py
@@ -79,6 +79,7 @@ def common(**kwargs):
     }
 
     if 'test' in sys.argv or 'jenkins' in sys.argv:
+        ENVIRONMENT = 'testing'
         DATABASES = {
             'default': {
                 'ENGINE': 'django.db.backends.sqlite3',
@@ -110,7 +111,7 @@ def common(**kwargs):
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
             'DIRS': [
-                os.path.join(base, "templates"),
+                os.path.join(base, 'templates'),
             ],
             'APP_DIRS': True,
             'OPTIONS': {

--- a/ctlsettings/templates/ctlsettings/sentry_js.html
+++ b/ctlsettings/templates/ctlsettings/sentry_js.html
@@ -1,0 +1,26 @@
+{% if SENTRY_KEY %}
+
+<script>
+    window.sentryOnLoad = function() {
+        Sentry.init({
+            environment: '{{ ENVIRONMENT }}'
+        });
+
+        {% if request.user.is_anonymous %}
+        Sentry.setUser({
+            email: 'none',
+            id: 'anonymous'
+        });
+        {% else %}
+        Sentry.setUser({
+            email: '{{ request.user.email }}',
+            id: '{{ request.user.username }}'
+        });
+        {% endif %}
+    };
+</script>
+
+<script src="https://js.sentry-cdn.com/{{ SENTRY_KEY }}.min.js"
+        crossorigin="anonymous"></script>
+
+{% endif %}

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     url='https://github.com/ccnmtl/ctlsettings',
     description='Columbia CTL common Django base settings',
     long_description='common settings we use across all our projects',
-    install_requires = [
+    install_requires=[
         'django-cas-ng',
         'django-debug-toolbar',
         'coverage',
@@ -23,9 +23,12 @@ setup(
         'gunicorn',
         'django-impersonate',
     ],
-    scripts = [],
-    license = 'GPL-3.0-or-later',
-    platforms = ['any'],
-    package_data = {'' : ['*.*']},
-    packages = ['ctlsettings'],
+    scripts=[],
+    license='GPL-3.0-or-later',
+    platforms=['any'],
+    packages=['ctlsettings', 'ctlsettings.templates'],
+    package_data={
+        'ctlsettings': ['*.py'],
+        'ctlsettings.templates': ['*/*.html'],
+    },
 )


### PR DESCRIPTION
This can be used in an application's base.html like this:
```
{% include "ctlsettings/sentry_js.html" %}
```

This should be included in the `<head>` tag, before all other javascript includes. It relies on the SENTRY_KEY local_setting to be present.