### PR TITLE
Add ctlsettings to base INSTALLED_APPS

### DIFF
--- a/ctlsettings/shared.py
+++ b/ctlsettings/shared.py
@@ -166,6 +166,7 @@ def common(**kwargs):
         'gunicorn',
         'impersonate',
         'django_cas_ng',
+        'ctlsettings',
     ]
 
     INTERNAL_IPS = ['127.0.0.1']


### PR DESCRIPTION
This is required in order to use the template file in this package. When this is enabled by default here, each application doesn't always need to include this in INSTALLED_APPS.