### PR TITLE
sentry-js: Wait for onLoad before using Sentry.setUser()

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.4.2
+====================
+* Updated sentry-js config to use Sentry.onLoad.
+
 0.4.1 (2024-10-11)
 ====================
 * Updated sentry JS config to use username instead of id.

--- a/ctlsettings/templates/ctlsettings/sentry_js.html
+++ b/ctlsettings/templates/ctlsettings/sentry_js.html
@@ -6,17 +6,21 @@
             environment: '{{ ENVIRONMENT }}'
         });
 
-        {% if request.user.is_anonymous %}
-        Sentry.setUser({
-            email: 'none',
-            username: 'anonymous'
+        Sentry.onLoad(function() {
+            const client = Sentry.getClient();
+
+            {% if request.user.is_anonymous %}
+            client.setUser({
+                email: 'none',
+                username: 'anonymous'
+            });
+            {% else %}
+            client.setUser({
+                email: '{{ request.user.email }}',
+                username: '{{ request.user.username }}'
+            });
+            {% endif %}
         });
-        {% else %}
-        Sentry.setUser({
-            email: '{{ request.user.email }}',
-            username: '{{ request.user.username }}'
-        });
-        {% endif %}
     };
 </script>
 


### PR DESCRIPTION
It looks like we need to wait for Sentry.onLoad to happen before calling this method, based on these docs:
https://docs.sentry.io/platforms/javascript/install/loader/#guarding-sdk-function-calls