### PR TITLE
Sentry JS: Configure user with initialScope

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+0.4.3
+====================
+* Updated sentry-js config again to be more failsafe, and also
+  configure user data in initialScope on initialization.
+
 0.4.2 (2024-10-14)
 ====================
 * Updated sentry-js config to use Sentry.onLoad.

--- a/ctlsettings/templates/ctlsettings/sentry_js.html
+++ b/ctlsettings/templates/ctlsettings/sentry_js.html
@@ -3,23 +3,21 @@
 <script>
     window.sentryOnLoad = function() {
         Sentry.init({
-            environment: '{{ ENVIRONMENT }}'
-        });
+            environment: '{{ ENVIRONMENT }}',
 
-        Sentry.onLoad(function() {
-            const client = Sentry.getClient();
-
-            {% if request.user.is_anonymous %}
-            client.setUser({
-                email: 'none',
-                username: 'anonymous'
-            });
-            {% else %}
-            client.setUser({
-                email: '{{ request.user.email }}',
-                username: '{{ request.user.username }}'
-            });
+            {% if request and request.user %}
+            initialScope: {
+                user: {
+                    {% if request.user.is_anonymous %}
+                    username: 'anonymous'
+                    {% else %}
+                    email: '{{ request.user.email }}',
+                    username: '{{ request.user.username }}'
+                    {% endif %}
+                }
+            }
             {% endif %}
+
         });
     };
 </script>


### PR DESCRIPTION
Based on the docs here:
https://docs.sentry.io/platforms/javascript/configuration/options/#initial-scope

My Sentry.onLoad and client.setUser setup doesn't seem to be working, and I don't think this is how things are intended to be used in Sentry.