### PR TITLE
Update django-storages class names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 0.4.6
 ====================
 * Removed dependency on django-stagingcontext
+* Updated S3Storage class locations for django-storages
 
 0.4.5 (2025-11-06)
 ====================

--- a/ctlsettings/storages.py
+++ b/ctlsettings/storages.py
@@ -1,7 +1,7 @@
-from storages.backends.s3boto3 import S3Boto3Storage, S3StaticStorage
+from storages.backends.s3 import S3Storage, S3StaticStorage
 
 
-class UploadsStorage(S3Boto3Storage):
+class UploadsStorage(S3Storage):
     location = 'uploads'
 
 


### PR DESCRIPTION
Use the updated class names rather than the compat shim at storages.backends.s3boto3. See:
  https://github.com/jschneier/django-storages/tree/master/storages/backends