### PR TITLE
Remove django-storages ACL config

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,8 @@
 ====================
 * Removed dependency on django-stagingcontext
 * Updated S3Storage class locations for django-storages
+* django-storages: remove public-read ACL. ACLs are deprecated in
+  favor of bucket policies.
 
 0.4.5 (2025-11-06)
 ====================

--- a/ctlsettings/production.py
+++ b/ctlsettings/production.py
@@ -39,9 +39,6 @@ def common(**kwargs):
     if s3static:
         # serve static files off S3
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-prod"
-        AWS_S3_OBJECT_PARAMETERS = {
-            'ACL': 'public-read',
-        }
         STORAGES = {
             'default': {
                 'BACKEND': 'ctlsettings.storages.UploadsStorage',

--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -31,9 +31,6 @@ def common(**kwargs):
     if s3static:
         # serve static files off S3
         AWS_STORAGE_BUCKET_NAME = s3prefix + "-" + project + "-static-stage"
-        AWS_S3_OBJECT_PARAMETERS = {
-            'ACL': 'public-read',
-        }
         STORAGES = {
             'default': {
                 'BACKEND': 'ctlsettings.storages.UploadsStorage',


### PR DESCRIPTION
I'm seeing this error in my ECS application when collectstatic runs:

> botocore.exceptions.ClientError: An error occurred (AccessControlListNotSupported)
> when calling the PutObject operation: The bucket does not allow ACLs

It seems that ACLs are deprecated and the current way to do this in AWS is via a bucket policy or using cloudfront.