### PR TITLE
Turn off debug=True for sentry staging setup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+0.4.7
+====================
+* Turn off debug=True for sentry staging setup.
+
 0.4.6 (2026-01-07)
 ====================
 * Removed dependency on django-stagingcontext

--- a/ctlsettings/staging.py
+++ b/ctlsettings/staging.py
@@ -94,7 +94,6 @@ def init_sentry(sentry_dsn: str) -> None:
         sentry_sdk.init(
             dsn=sentry_dsn,
             integrations=[DjangoIntegration()],
-            debug=True,
             environment='staging',
             traces_sample_rate=1.0,
         )


### PR DESCRIPTION
This option is emitting a lot of unnecessary logging which we don't need, which is actually filling up our syslog files on staging.